### PR TITLE
feat: add kid generation according to kubernetes

### DIFF
--- a/docs/data-sources/from_certificate.md
+++ b/docs/data-sources/from_certificate.md
@@ -35,13 +35,13 @@ data "jwks_from_certificate" "pem_example_2" {
 
 ### Optional
 
-- `kid` (String) Used to override the `kid` field of the JWK
-- `use` (String) Used to populate the `use` field of the JWK.
-- `alg` (String) Used to populate the `alg` field of the JWK.
+- `alg` (String) Used to populate the alg field of the JWK
+- `id` (String) The ID of this resource.
+- `kid` (String) Used to override the kid field of the JWK
+- `use` (String) Used to populate the use field of the JWK
 
 ### Read-Only
 
-- `id` (String) The ID of this resource.
 - `jwks` (String) The calculated JWKS
 
 

--- a/docs/data-sources/from_key.md
+++ b/docs/data-sources/from_key.md
@@ -48,13 +48,14 @@ data "jwks_from_key" "base64_der_example" {
 
 ### Optional
 
-- `kid` (String) Used to populate the `kid` field of the JWK.
-- `use` (String) Used to populate the `use` field of the JWK.
-- `alg` (String) Used to populate the `alg` field of the JWK.
+- `alg` (String) Used to populate the alg field of the JWK.
+- `generate_kid` (Boolean) Used to populate the kid field of the JWK with the a key ID non-reversibly from the public key (only with public keys in PEM format). See https://github.com/kubernetes/kubernetes/blob/0f140bf1eeaf63c155f5eba1db8db9b5d52d5467/pkg/serviceaccount/jwt.go#L98
+- `id` (String) The ID of this resource.
+- `kid` (String) Used to populate the kid field of the JWK.
+- `use` (String) Used to populate the use field of the JWK.
 
 ### Read-Only
 
-- `id` (String) The ID of this resource.
 - `jwks` (String) The calculated JSON Web Key Sets.
 
 

--- a/internal/sdkv2provider/data_source_jwks_from_key_test.go
+++ b/internal/sdkv2provider/data_source_jwks_from_key_test.go
@@ -149,6 +149,12 @@ func TestAccJwksFromKeyDataSource(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "jwks", `{"alg":"RS256","e":"AQAB","kty":"RSA","n":"gUElV5mwqkloIrM8ZNZ72gSCcnSJt7-_Usa5G-D15YQUAdf9c1zEekTfHgDP-04nw_uFNFaE5v1RbHaPxhZYVg5ZErNCa_hzn-x10xzcepeS3KPVXcxae4MR0BEegvqZqJzN9loXsNL_c3H_B-2Gle3hTxjlWFb3F5qLgR-4Mf4ruhER1v6eHQa_nchi03MBpT4UeJ7MrL92hTJYLdpSyCqmr8yjxkKJDVC2uRrr-sTSxfh7r6v24u_vp_QTmBIAlNPgadVAZw17iNNb7vjV7Gwl_5gHXonCUKURaV--dBNLrHIZpqcAM8wHRph8mD1EfL9hsz77pHewxolBATV-7Q"}`),
 				),
 			},
+			{
+				Config: testAccJwksFromKeyWithGenerateKidDataSourceConfig(ecPublicKeyDer()),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "jwks", `{"crv":"P-384","kid":"ZgtsBVoa8fdL4gQGYjFJdZVMbQV2LQ3LVnbfZWrT_Nw","kty":"EC","x":"QnSqFbKGdEiz_g0CoZFXBAvsMMbMBqqnZ3jJ_zrLxuBShDTmrsRoU7MCOALbt04f","y":"FoRI8H06aS1Wq1XsAbMiMLUqpl5joOWeUChxyPb0v-7B86IE9299UHBpbAfcnthd"}`),
+				),
+			},
 		},
 	})
 }
@@ -198,6 +204,17 @@ EOF
 		alg = "%s"
 	}
 	`, data, alg)
+}
+
+func testAccJwksFromKeyWithGenerateKidDataSourceConfig(data string) string {
+	return fmt.Sprintf(`
+	data "jwks_from_key" "test" {
+		key = <<EOF
+%s
+EOF
+		generate_kid = true
+	}
+	`, data)
 }
 
 func privateKeyDer() string {


### PR DESCRIPTION
I suggest to include this feat from @jlmwork. I was going to program it but found his work first. 

### Description:
Used to populate the kid field of the JWK with the a key ID non-reversibly from the public key (only with public keys in PEM format).`

[See inline comment ](https://github.com/kubernetes/kubernetes/blob/0f140bf1eeaf63c155f5eba1db8db9b5d52d5467/pkg/serviceaccount/jwt.go#L98) 

### Notes: 
1. Work done by https://github.com/jlmwork/terraform-provider-jwks/commit/f2374a74d7b70ad26ac360b7b87b4a6286e072e3
2. I rebase the code since his work was done a while ago
3. I updated the docs